### PR TITLE
Kill pids on used ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 poolparty/stride/*
-
+poolparty/launch_poolparty.sh
 **.DS_STORE

--- a/poolparty/init_poolparty.sh
+++ b/poolparty/init_poolparty.sh
@@ -117,4 +117,13 @@ while true; do
     esac
 done
 
+# kill ports if they're already running
+PORT_NUMBER=6060
+lsof -i tcp:${PORT_NUMBER} | awk 'NR!=1 {print $2}' | xargs kill
+PORT_NUMBER=26657
+lsof -i tcp:${PORT_NUMBER} | awk 'NR!=1 {print $2}' | xargs kill 
+PORT_NUMBER=26557
+lsof -i tcp:${PORT_NUMBER} | awk 'NR!=1 {print $2}' | xargs kill
+
+
 sh $launch_file

--- a/poolparty/launch_poolparty.sh
+++ b/poolparty/launch_poolparty.sh
@@ -1,1 +1,0 @@
-/Users/aidansalzmann/stride/testnet/poolparty/stride//build/strided start --home /Users/aidansalzmann/stride/testnet/poolparty/stride//build/stride/

--- a/poolparty/launch_poolparty.sh
+++ b/poolparty/launch_poolparty.sh
@@ -1,0 +1,1 @@
+/Users/aidansalzmann/stride/testnet/poolparty/stride//build/strided start --home /Users/aidansalzmann/stride/testnet/poolparty/stride//build/stride/


### PR DESCRIPTION
The script uses ports 6060, 26657, 26557. If a process is running on any of these, the chain won't launch

also adds launch_poolparty.sh to .gitignore