### PR TITLE
Update init_poolparty.sh

### DIFF
--- a/poolparty/init_poolparty.sh
+++ b/poolparty/init_poolparty.sh
@@ -23,7 +23,7 @@ printf "This script will guide you through setting up your very own Stride node 
 printf "You're currently running $BOLD$SCRIPT_VERSION$NC of the setup script.\n\n"
 
 printf "Before we begin, let's make sure you have all the required dependencies installed.\n"
-DEPENDENCIES=( "git" "go" "jq" "lsof" "gcc" )
+DEPENDENCIES=( "git" "go" "jq" "lsof" "gcc" "libc6" "libc6-dev" )
 missing_deps=false
 for dep in ${DEPENDENCIES[@]}; do
     printf "\t%-8s" "$dep..."


### PR DESCRIPTION
needs libc6-dev libc6 installed deps, otherwise:

go: downloading github.com/opencontainers/go-digest v1.0.0
# runtime/cgo
_cgo_export.c:3:10: fatal error: stdlib.h: No such file or directory
    3 | #include <stdlib.h>
      |          ^~~~~~~~~~