### PR TITLE
fixed related path in cosmovisor

### DIFF
--- a/poolparty/init_poolparty.sh
+++ b/poolparty/init_poolparty.sh
@@ -142,7 +142,7 @@ install_cosmovisor() {
     cd cosmos-sdk 
     git checkout cosmovisor/v1.1.0 >> $LOG_PATH 2>&1
     make cosmovisor >> $LOG_PATH 2>&1
-    mv $STRIDE_FOLDER/cosmovisor/cosmovisor "$BINARY_LOCATION/cosmovisor${suffix}"
+    mv .cosmovisor/cosmovisor "$BINARY_LOCATION/cosmovisor${suffix}"
 
     cd ..
     rm -rf cosmos-sdk

--- a/poolparty/init_poolparty.sh
+++ b/poolparty/init_poolparty.sh
@@ -142,7 +142,7 @@ install_cosmovisor() {
     cd cosmos-sdk 
     git checkout cosmovisor/v1.1.0 >> $LOG_PATH 2>&1
     make cosmovisor >> $LOG_PATH 2>&1
-    mv .cosmovisor/cosmovisor "$BINARY_LOCATION/cosmovisor${suffix}"
+    mv ./cosmovisor/cosmovisor "$BINARY_LOCATION/cosmovisor${suffix}"
 
     cd ..
     rm -rf cosmos-sdk


### PR DESCRIPTION
The `cosmovisor` in installed under the `$INSTALL_FOLDER` (`INSTALL_FOLDER="$HOME/.stride/$TESTNET"`), so the real path of the binary is `$HOME/.stride/$TESTNET/cosmos-sdk/cosmovisor/cosmovisor`.
Since we are already under the `cosmos-sdk` folder, we can use the relative path for simplicity.